### PR TITLE
fix: restore legorafi.fr (humoristic french website)

### DIFF
--- a/adblock.txt
+++ b/adblock.txt
@@ -479,7 +479,6 @@
 ||GlobalEconomicAnalysis.com^
 ||GonzaloLira.Blogspot.com^
 ||katehon.org^
-||legorafi.fr^
 ||lightlybraisedturnip.com^
 ||livefreelivenatural.com^
 ||mydailyrelaxation.com^

--- a/dnsmasq_hosts.txt
+++ b/dnsmasq_hosts.txt
@@ -479,7 +479,6 @@
 0.0.0.0 GlobalEconomicAnalysis.com www.GlobalEconomicAnalysis.com
 0.0.0.0 GonzaloLira.Blogspot.com www.GonzaloLira.Blogspot.com
 0.0.0.0 katehon.org www.katehon.org
-0.0.0.0 legorafi.fr www.legorafi.fr
 0.0.0.0 lightlybraisedturnip.com www.lightlybraisedturnip.com
 0.0.0.0 livefreelivenatural.com www.livefreelivenatural.com
 0.0.0.0 mydailyrelaxation.com www.mydailyrelaxation.com

--- a/dnsmasq_hosts.txt.ipv6
+++ b/dnsmasq_hosts.txt.ipv6
@@ -479,7 +479,6 @@
 ::1 GlobalEconomicAnalysis.com www.GlobalEconomicAnalysis.com
 ::1 GonzaloLira.Blogspot.com www.GonzaloLira.Blogspot.com
 ::1 katehon.org www.katehon.org
-::1 legorafi.fr www.legorafi.fr
 ::1 lightlybraisedturnip.com www.lightlybraisedturnip.com
 ::1 livefreelivenatural.com www.livefreelivenatural.com
 ::1 mydailyrelaxation.com www.mydailyrelaxation.com

--- a/etc_hosts.txt
+++ b/etc_hosts.txt
@@ -960,8 +960,6 @@
 0.0.0.0 www.GonzaloLira.Blogspot.com
 0.0.0.0 katehon.org
 0.0.0.0 www.katehon.org
-0.0.0.0 legorafi.fr
-0.0.0.0 www.legorafi.fr
 0.0.0.0 lightlybraisedturnip.com
 0.0.0.0 www.lightlybraisedturnip.com
 0.0.0.0 livefreelivenatural.com

--- a/etc_hosts.txt.ipv6
+++ b/etc_hosts.txt.ipv6
@@ -960,8 +960,6 @@
 ::1 www.GonzaloLira.Blogspot.com
 ::1 katehon.org
 ::1 www.katehon.org
-::1 legorafi.fr
-::1 www.legorafi.fr
 ::1 lightlybraisedturnip.com
 ::1 www.lightlybraisedturnip.com
 ::1 livefreelivenatural.com


### PR DESCRIPTION
Remove legorafi.fr website

It's a french humoristic website, even its name it's derivated from "lefigaro.fr" which is a well-known press in France.

You can check on Wikipedia, it's described as "The Gorafi is a French parody information site"
- https://fr.wikipedia.org/wiki/Le_Gorafi
- https://en.wikipedia.org/wiki/Le_Gorafi


All articles on legorafi.fr are humoristic.
It's obviously (at least for French natives) humor, see the last titles:
- "A Parisian tries the adventure of his life by exceptionally taking the bus instead of the metro"
- "End of COVID restrictions – Parisians allowed again to lick subway bars"

... idk what to says more than "😂" 

