### PR TITLE
Remove dissentmagazine.org false positive

### DIFF
--- a/adblock.txt
+++ b/adblock.txt
@@ -405,7 +405,6 @@
 ||counterpunch.org^
 ||davidstockmanscontracorner.com^
 ||dennismichaellynch.com^
-||dissentmagazine.org^
 ||ecowatch.com^
 ||emptywheel.net^
 ||filmsforaction.org^

--- a/dnsmasq_hosts.txt
+++ b/dnsmasq_hosts.txt
@@ -399,7 +399,6 @@
 0.0.0.0 counterpunch.org www.counterpunch.org
 0.0.0.0 davidstockmanscontracorner.com www.davidstockmanscontracorner.com
 0.0.0.0 dennismichaellynch.com www.dennismichaellynch.com
-0.0.0.0 dissentmagazine.org www.dissentmagazine.org
 0.0.0.0 ecowatch.com www.ecowatch.com
 0.0.0.0 emptywheel.net www.emptywheel.net
 0.0.0.0 filmsforaction.org www.filmsforaction.org

--- a/dnsmasq_hosts.txt.ipv6
+++ b/dnsmasq_hosts.txt.ipv6
@@ -399,7 +399,6 @@
 ::1 counterpunch.org www.counterpunch.org
 ::1 davidstockmanscontracorner.com www.davidstockmanscontracorner.com
 ::1 dennismichaellynch.com www.dennismichaellynch.com
-::1 dissentmagazine.org www.dissentmagazine.org
 ::1 ecowatch.com www.ecowatch.com
 ::1 emptywheel.net www.emptywheel.net
 ::1 filmsforaction.org www.filmsforaction.org

--- a/etc_hosts.txt
+++ b/etc_hosts.txt
@@ -800,8 +800,6 @@
 0.0.0.0 www.davidstockmanscontracorner.com
 0.0.0.0 dennismichaellynch.com
 0.0.0.0 www.dennismichaellynch.com
-0.0.0.0 dissentmagazine.org
-0.0.0.0 www.dissentmagazine.org
 0.0.0.0 ecowatch.com
 0.0.0.0 www.ecowatch.com
 0.0.0.0 emptywheel.net

--- a/etc_hosts.txt.ipv6
+++ b/etc_hosts.txt.ipv6
@@ -800,8 +800,6 @@
 ::1 www.davidstockmanscontracorner.com
 ::1 dennismichaellynch.com
 ::1 www.dennismichaellynch.com
-::1 dissentmagazine.org
-::1 www.dissentmagazine.org
 ::1 ecowatch.com
 ::1 www.ecowatch.com
 ::1 emptywheel.net

--- a/netsane.txt
+++ b/netsane.txt
@@ -399,7 +399,6 @@
 "*://*.counterpunch.org/*",
 "*://*.davidstockmanscontracorner.com/*",
 "*://*.dennismichaellynch.com/*",
-"*://*.dissentmagazine.org/*",
 "*://*.ecowatch.com/*",
 "*://*.emptywheel.net/*",
 "*://*.filmsforaction.org/*",


### PR DESCRIPTION
dissentmagazine.org is a pretty blatant false positive, given the extant content and professed bias of the site: https://www.dissentmagazine.org/about-dissent-magazine

This is about as far from q conspiracy nonsense as you are ever going to get.