### PR TITLE
add websites related to sott.net and Laura Knight-Jadczyk

### DIFF
--- a/adblock.txt
+++ b/adblock.txt
@@ -3034,3 +3034,8 @@
 ||mg.show^
 ||profundityyours.com^
 ||twc.health^
+||cassiopaea.org^
+||cassiopaea.com^
+||paleochristianity.org^
+||quantumfuturegroup.org^
+||montalk.net^

--- a/dnsmasq_hosts.txt
+++ b/dnsmasq_hosts.txt
@@ -3032,3 +3032,8 @@
 0.0.0.0 mg.show www.mg.show
 0.0.0.0 profundityyours.com www.profundityyours.com
 0.0.0.0 twc.health www.twc.health
+0.0.0.0 cassiopaea.org www.cassiopaea.org
+0.0.0.0 cassiopaea.com www.cassiopaea.com
+0.0.0.0 paleochristianity.org www.paleochristianity.org
+0.0.0.0 quantumfuturegroup.org www.quantumfuturegroup.org
+0.0.0.0 montalk.net www.montalk.net

--- a/dnsmasq_hosts.txt.ipv6
+++ b/dnsmasq_hosts.txt.ipv6
@@ -3032,3 +3032,8 @@
 ::1 mg.show www.mg.show
 ::1 profundityyours.com www.profundityyours.com
 ::1 twc.health www.twc.health
+::1 cassiopaea.org www.cassiopaea.org
+::1 cassiopaea.com www.cassiopaea.com
+::1 paleochristianity.org www.paleochristianity.org
+::1 quantumfuturegroup.org www.quantumfuturegroup.org
+::1 montalk.net www.montalk.net

--- a/etc_hosts.txt
+++ b/etc_hosts.txt
@@ -6054,3 +6054,13 @@
 0.0.0.0 www.profundityyours.com
 0.0.0.0 twc.health
 0.0.0.0 www.twc.health
+0.0.0.0 cassiopaea.org
+0.0.0.0 www.cassiopaea.org
+0.0.0.0 cassiopaea.com
+0.0.0.0 www.cassiopaea.com
+0.0.0.0 paleochristianity.org
+0.0.0.0 www.paleochristianity.org
+0.0.0.0 quantumfuturegroup.org
+0.0.0.0 www.quantumfuturegroup.org
+0.0.0.0 montalk.net
+0.0.0.0 www.montalk.net

--- a/etc_hosts.txt.ipv6
+++ b/etc_hosts.txt.ipv6
@@ -6054,3 +6054,13 @@
 ::1 www.profundityyours.com
 ::1 twc.health
 ::1 www.twc.health
+::1 cassiopaea.org
+::1 www.cassiopaea.org
+::1 cassiopaea.com
+::1 www.cassiopaea.com
+::1 paleochristianity.org
+::1 www.paleochristianity.org
+::1 quantumfuturegroup.org
+::1 www.quantumfuturegroup.org
+::1 montalk.net
+::1 www.montalk.net

--- a/netsane.txt
+++ b/netsane.txt
@@ -3026,3 +3026,8 @@
 "*://*.mg.show/*",
 "*://*.profundityyours.com/*",
 "*://*.twc.health/*",
+"*://*.cassiopaea.org/*",
+"*://*.cassiopaea.com/*",
+"*://*.paleochristianity.org/*",
+"*://*.quantumfuturegroup.org/*",
+"*://*.montalk.net/*",


### PR DESCRIPTION
For information about how these sites are all related, see [here](https://rationalwiki.org/wiki/Laura_Knight-Jadczyk) and [here](https://rationalwiki.org/wiki/Montalk). There are also some more websites related to LKJ mentioned in the first article, though they are more peripheral.