### PR TITLE
add brasil far-right content producer website

### DIFF
--- a/sources/default.txt
+++ b/sources/default.txt
@@ -3003,3 +3003,4 @@ joedubs.com
 rusvesna.su
 journal-neo.su
 strategic-culture.su
+brasilparalelo.com.br


### PR DESCRIPTION
Brasil Paralelo is a major producer of fake news and far-right revisionism in Brazil.